### PR TITLE
Instructor can display and broadcast message to queue

### DIFF
--- a/app/assets/javascripts/components/course_queue_client_action_handler.js
+++ b/app/assets/javascripts/components/course_queue_client_action_handler.js
@@ -55,3 +55,9 @@ CourseQueueClientActionHandler.prototype.cancelRequest = function (id) {
     id: id,
   });
 };
+
+CourseQueueClientActionHandler.prototype.broadcastMessage = function (action, message) {
+  this.subscription.perform(action, {
+    message: message
+  });
+};

--- a/app/assets/javascripts/components/instructor_message.js.jsx
+++ b/app/assets/javascripts/components/instructor_message.js.jsx
@@ -5,29 +5,22 @@ var InstructorMessage = React.createClass({
       instructorMessage: this.props.instructorMessage,
     };
   },
-  buttonBaseClass: "ui fluid button ",
   update: function (event) {
     this.setState({
       instructorMessage: event.target.value,
     });
   },
+  // allows <a> elements with an href to be tab indexable and handle the onEnter
+  // event by default
+  NO_LINK: "#",
   componentWillReceiveProps: function (nextProps) {
     // don't overwrite what we're editing
     if ((this.props.instructorMessage || nextProps.instructorMessage)
          && !this.state.editMode) {
 
-      // empty the message if the queue closes
-      if (this.props.instructors.length > 0 &&
-          nextProps.instructors.length <= 0){
-
-        this.setState({ instructorMessage: '' }, function (){
-          this.updateMessage();
-        });
-      } else {
-        this.setState({
-          instructorMessage: nextProps.instructorMessage,
-        });
-      }
+      this.setState({
+        instructorMessage: nextProps.instructorMessage,
+      });
     }
   },
   updateMessage: function () {
@@ -54,54 +47,67 @@ var InstructorMessage = React.createClass({
   },
   renderBroadcastBtn: function () {
     return (
-      <button type="button" onClick={this.broadcastConfirm} className={this.buttonBaseClass} tabIndex="0">
-        <i className="send outline icon"></i>
-        {this.state.editMode ? "Save and Broadcast" : "Broadcast"}
-      </button>
+      <a onClick={this.broadcastConfirm} className="item" href={this.NO_LINK} role="button">
+        Broadcast
+      </a>
     );
   },
   renderEditOrSaveBtn: function () {
     if (this.state.editMode){
       return (
-        <button type="button" onClick={this.save} className={this.buttonBaseClass} tabIndex="0">
-          <i className="save icon"></i>
-            Save
-        </button>
+        <a onClick={this.save} className="item" href={this.NO_LINK} role="button">
+          Save
+        </a>
       );
     } else {
       return (
-        <button type="button" onClick={this.updateEditMode.bind(this, true)} className={this.buttonBaseClass} tabIndex="0">
-          <i className="edit icon"></i>
-            Edit
-        </button>
+        <a onClick={this.updateEditMode.bind(this, true)} className="item" href={this.NO_LINK} role="button">
+          Edit
+        </a>
       );
     }
   },
-  renderButtons: function () {
-    return (
-      <div className="ui stackable grid">
-        <div className="ui six wide column">
-          <div className="ui icon two buttons">
-            {this.renderEditOrSaveBtn()}
-            {this.renderBroadcastBtn()}
+  renderText: function () {
+    if (this.state.editMode){
+      return (
+        <div className="ui form">
+          <div className="field">
+            <textarea rows="1" onChange={this.update} value={this.state.instructorMessage} type="text"></textarea>
           </div>
+        </div>
+      );
+    } else {
+      return (
+        <div className="ui fluid">
+          { this.state.instructorMessage ? this.state.instructorMessage : <i>No message yet</i> }
+        </div>
+      );
+    }
+  },
+  renderBoldSectionOfHeader: function() {
+    return (
+      <div className="item">
+        <div className="content">
+          <div className="header">Instructor's message</div>
         </div>
       </div>
     );
   },
+  renderHeader: function() {
+    return (
+      <div className="ui horizontal list">
+        {this.renderBoldSectionOfHeader()}
+        {this.renderEditOrSaveBtn()}
+        {this.renderBroadcastBtn()}
+      </div>
+    );
+  },
   renderInstructorMode: function () {
-    var isDisabled = true;
-    if (this.state.editMode){
-      isDisabled = false;
-    }
     return (
       <div className="sixteen wide column">
         <div className="ui message">
-          <div className="bottom padded header">Instructor's message</div>
-          <div className="ui bottom padded fluid input">
-            <input disabled={isDisabled} onChange={this.update} value={this.state.instructorMessage} type="text" maxLength="150" />
-          </div>
-          {this.renderButtons()}
+          {this.renderHeader()}
+          {this.renderText()}
         </div>
       </div>
     );
@@ -128,7 +134,7 @@ var InstructorMessage = React.createClass({
     var messageBar = null;
     if (this.props.instructorMode){
       messageBar = this.renderInstructorMode();
-    } else if (this.props.instructors.length > 0) {
+    } else {
       messageBar = this.renderStudentMode();
     }
     return messageBar;

--- a/app/assets/javascripts/components/instructor_message.js.jsx
+++ b/app/assets/javascripts/components/instructor_message.js.jsx
@@ -1,0 +1,136 @@
+var InstructorMessage = React.createClass({
+  getInitialState: function () {
+    return {
+      editMode: false,
+      instructorMessage: this.props.instructorMessage,
+    };
+  },
+  buttonBaseClass: "ui fluid button ",
+  update: function (event) {
+    this.setState({
+      instructorMessage: event.target.value,
+    });
+  },
+  componentWillReceiveProps: function (nextProps) {
+    // don't overwrite what we're editing
+    if ((this.props.instructorMessage || nextProps.instructorMessage)
+         && !this.state.editMode) {
+
+      // empty the message if the queue closes
+      if (this.props.instructors.length > 0 &&
+          nextProps.instructors.length <= 0){
+
+        this.setState({ instructorMessage: '' }, function (){
+          this.updateMessage();
+        });
+      } else {
+        this.setState({
+          instructorMessage: nextProps.instructorMessage,
+        });
+      }
+    }
+  },
+  updateMessage: function () {
+    this.setState({ instructorMessage: this.state.instructorMessage.trim() }, function () {
+      this.props.updateInstructorMessage('update_instructor_message',
+                                         this.state.instructorMessage);
+    });
+  },
+  broadcastConfirm: function () {
+    if (confirm("Broadcast:\n" + this.state.instructorMessage + "\nTo the entire queue?")){
+      this.save()
+      this.props.broadcastInstructorMessage('broadcast_instructor_message',
+                                            this.state.instructorMessage);
+    }
+  },
+  updateEditMode: function (state) {
+    this.setState({
+      editMode: state
+    });
+  },
+  save: function (){
+    this.updateEditMode(false);
+    this.updateMessage();
+  },
+  renderBroadcastBtn: function () {
+    return (
+      <button type="button" onClick={this.broadcastConfirm} className={this.buttonBaseClass} tabIndex="0">
+        <i className="send outline icon"></i>
+        {this.state.editMode ? "Save and Broadcast" : "Broadcast"}
+      </button>
+    );
+  },
+  renderEditOrSaveBtn: function () {
+    if (this.state.editMode){
+      return (
+        <button type="button" onClick={this.save} className={this.buttonBaseClass} tabIndex="0">
+          <i className="save icon"></i>
+            Save
+        </button>
+      );
+    } else {
+      return (
+        <button type="button" onClick={this.updateEditMode.bind(this, true)} className={this.buttonBaseClass} tabIndex="0">
+          <i className="edit icon"></i>
+            Edit
+        </button>
+      );
+    }
+  },
+  renderButtons: function () {
+    return (
+      <div className="ui stackable grid">
+        <div className="ui six wide column">
+          <div className="ui icon two buttons">
+            {this.renderEditOrSaveBtn()}
+            {this.renderBroadcastBtn()}
+          </div>
+        </div>
+      </div>
+    );
+  },
+  renderInstructorMode: function () {
+    var isDisabled = true;
+    if (this.state.editMode){
+      isDisabled = false;
+    }
+    return (
+      <div className="sixteen wide column">
+        <div className="ui message">
+          <div className="bottom padded header">Instructor's message</div>
+          <div className="ui bottom padded fluid input">
+            <input disabled={isDisabled} onChange={this.update} value={this.state.instructorMessage} type="text" maxLength="150" />
+          </div>
+          {this.renderButtons()}
+        </div>
+      </div>
+    );
+  },
+  renderStudentMode: function () {
+    if (this.state.instructorMessage){
+      var pluralLetter = this.props.instructors.length > 1 ? 's' : ''
+      return (
+        <div className="sixteen wide column">
+          <Message
+           title={"Message from the instructor" + pluralLetter}
+           message={this.state.instructorMessage} />
+        </div>
+      );
+    } else {
+      return null;
+    }
+  },
+  render: function () {
+    if (!this.props.enabled){
+      return null;
+    }
+
+    var messageBar = null;
+    if (this.props.instructorMode){
+      messageBar = this.renderInstructorMode();
+    } else if (this.props.instructors.length > 0) {
+      messageBar = this.renderStudentMode();
+    }
+    return messageBar;
+  }
+});

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -31,6 +31,23 @@ class QueueChannel < ApplicationCable::Channel
     })
   end
 
+  def update_instructor_message(data)
+      authorize :instructor_only
+      @course_queue.update_instructor_message!(data['message'])
+
+      publish_data('update_instructor_message', data['message'])
+  end
+
+  def broadcast_instructor_message(data)
+      authorize :instructor_only
+
+      QueueChannel.broadcast_to(@course_queue, {
+        action: 'broadcast_instructor_message',
+        message: data['message'],
+        instructor: current_user,
+      })
+  end
+
   def pin(data)
     authorize :instructor_only
 
@@ -116,6 +133,13 @@ class QueueChannel < ApplicationCable::Channel
       action: action,
       request: serialize_request(request),
     })
+  end
+
+  def publish_data(action, message)
+      QueueChannel.broadcast_to(@course_queue, {
+          action: action,
+          message: message
+      })
   end
 
   def load_request(data)

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -35,7 +35,11 @@ class QueueChannel < ApplicationCable::Channel
       authorize :instructor_only
       @course_queue.update_instructor_message!(data['message'])
 
-      publish_data('update_instructor_message', data['message'])
+      QueueChannel.broadcast_to(@course_queue, {
+          action: update_instructor_message,
+          message: data['message'],
+      })
+
   end
 
   def broadcast_instructor_message(data)
@@ -133,13 +137,6 @@ class QueueChannel < ApplicationCable::Channel
       action: action,
       request: serialize_request(request),
     })
-  end
-
-  def publish_data(action, message)
-      QueueChannel.broadcast_to(@course_queue, {
-          action: action,
-          message: message
-      })
   end
 
   def load_request(data)

--- a/app/controllers/course_queues_controller.rb
+++ b/app/controllers/course_queues_controller.rb
@@ -22,6 +22,11 @@ class CourseQueuesController < ApplicationController
     @instructors = @course_queue.online_instructors
   end
 
+  # GET /course_queues/1/instructor_message.json
+  def instructor_message
+    @instructor_message = @course_queue.instructor_message
+  end
+
   private
   def set_course_queue
     @course_queue = CourseQueue.find(params[:id])

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -31,6 +31,11 @@ class CourseQueue < ApplicationRecord
     course_queue_entries.where(resolved_at: nil).order('created_at ASC')
   end
 
+  def update_instructor_message!(message)
+      self.instructor_message = message
+      self.save!
+  end
+
   def pop!(user)
     if first_pinned = self.outstanding_requests.where(resolver: user).first
       first_pinned.resolve_by!(user)

--- a/app/views/course_queues/instructor_message.json.jbuilder
+++ b/app/views/course_queues/instructor_message.json.jbuilder
@@ -1,0 +1,1 @@
+json.instructor_message @instructor_message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     member do
       get 'outstanding_requests'
       get 'online_instructors'
+      get 'instructor_message'
     end
   end
 

--- a/db/migrate/20170424200546_add_instructor_to_course_queue.rb
+++ b/db/migrate/20170424200546_add_instructor_to_course_queue.rb
@@ -1,5 +1,5 @@
 class AddInstructorToCourseQueue < ActiveRecord::Migration[5.0]
   def change
-    add_column :course_queues, :instructor_message, :string
+    add_column :course_queues, :instructor_message, :text
   end
 end

--- a/db/migrate/20170424200546_add_instructor_to_course_queue.rb
+++ b/db/migrate/20170424200546_add_instructor_to_course_queue.rb
@@ -1,0 +1,5 @@
+class AddInstructorToCourseQueue < ActiveRecord::Migration[5.0]
+  def change
+    add_column :course_queues, :instructor_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170215215714) do
+ActiveRecord::Schema.define(version: 20170424200546) do
 
   create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "course_group_id", null: false
@@ -56,14 +56,15 @@ ActiveRecord::Schema.define(version: 20170215215714) do
   end
 
   create_table "course_queues", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name",                                      null: false
+    t.string   "name",                                             null: false
     t.string   "location"
-    t.text     "description", limit: 65535
+    t.text     "description",        limit: 65535
     t.boolean  "is_open"
-    t.integer  "course_id",                                 null: false
-    t.datetime "created_at",                                null: false
-    t.datetime "updated_at",                                null: false
-    t.boolean  "group_mode",                default: false, null: false
+    t.integer  "course_id",                                        null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.boolean  "group_mode",                       default: false, null: false
+    t.string   "instructor_message"
     t.index ["course_id", "name"], name: "index_course_queues_on_course_id_and_name", unique: true, using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20170424200546) do
     t.datetime "created_at",                                       null: false
     t.datetime "updated_at",                                       null: false
     t.boolean  "group_mode",                       default: false, null: false
-    t.string   "instructor_message"
+    t.text     "instructor_message", limit: 65535
     t.index ["course_id", "name"], name: "index_course_queues_on_course_id_and_name", unique: true, using: :btree
   end
 


### PR DESCRIPTION
This feature adds the ability for instructors to create and save a message at the top of a course queue. Instructors can choose to broadcast the message to everyone on the queue as well as have it displayed on the top of the queue, or just post their message silently. This closes #86. 

**Note**: the gif recording software didn't record with the best resolution. There are some graphical artifacts in the gifs that aren't present in the actual build

- Ability to broadcast message to all students on the queue (using incognito on the right window, so I couldn't opt in for the notifications instead of alert popups)
![broadcast_message](https://cloud.githubusercontent.com/assets/8933413/25553342/6015126c-2c7e-11e7-9fd1-2638b89a3f0c.gif)

- Display message at the top of all queues
![screen shot 2017-04-29 at 1 45 38 am](https://cloud.githubusercontent.com/assets/8933413/25553292/952f3820-2c7d-11e7-88e6-90e8049f783f.png)

- Clears the message and does not display the message info to students when all instructors are offline
![clear_message](https://cloud.githubusercontent.com/assets/8933413/25553272/f27fd332-2c7c-11e7-9f59-86957f9d6de5.gif)

- Follows with the responsive design of the site
![responsive](https://cloud.githubusercontent.com/assets/8933413/25553348/a2067ec2-2c7e-11e7-8915-ea219ced7f5a.gif)


- Any instructor can edit the message
- Blank messages, when entered, aren't displayed