### PR TITLE
Allow messages to display newlines

### DIFF
--- a/app/assets/javascripts/components/instructor_message.js.jsx
+++ b/app/assets/javascripts/components/instructor_message.js.jsx
@@ -78,7 +78,7 @@ var InstructorMessage = React.createClass({
       );
     } else {
       return (
-        <div className="ui fluid">
+        <div className="ui fluid ack-white-space">
           { this.state.instructorMessage ? this.state.instructorMessage : <i>No message yet</i> }
         </div>
       );

--- a/app/assets/javascripts/components/message.js.jsx
+++ b/app/assets/javascripts/components/message.js.jsx
@@ -3,7 +3,7 @@ var Message = React.createClass({
     return (
       <div className="ui message">
           <div className="header">{this.props.title}</div>
-          <p>{this.props.message}</p>
+          <p className="ack-white-space">{this.props.message}</p>
       </div>
     );
   }

--- a/app/assets/stylesheets/scaffold.css
+++ b/app/assets/stylesheets/scaffold.css
@@ -48,3 +48,7 @@
     border-left: 2px solid #FBBD08 !important;
     padding-left: 10px !important;
 }
+
+.ack-white-space {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
Previously, messages would discard newline characters and just display them as a
space. Now, newlines are acknowledged and allow for prettier formatted messages. Although newlines are most affected by this, the new CSS affects whitespace in general.


**Previously:**

![screen shot 2017-08-13 at 5 45 12 pm](https://user-images.githubusercontent.com/8933413/29255792-971b5d0a-8059-11e7-891a-74c1ea735a98.png)

**Now:**
![screen shot 2017-08-13 at 5 46 02 pm](https://user-images.githubusercontent.com/8933413/29255795-9d580402-8059-11e7-8d07-7e8af231f146.png)

Closes #104 