### PR TITLE
Specify language

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>Office Hours Help Queue</title>
         <%= csrf_meta_tags %>


### PR DESCRIPTION
For some reason Chrome wants to translate our pages from Catalan.