### PR TITLE
Create default queue with new course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,6 +7,8 @@ class Course < ApplicationRecord
   has_many :instructors, through: :course_instructors
   has_many :course_queue_entries, through: :course_queues
 
+  after_create :create_default_queue
+
   # Produce a deterministic but secret code used to self-enroll instructors
   def enrollment_code
     OpenSSL::HMAC.hexdigest(
@@ -112,5 +114,13 @@ class Course < ApplicationRecord
 
   def to_param
     slug
+  end
+
+  protected
+  def create_default_queue
+    course_queues.create!(
+      name: 'Office Hours',
+      location: 'TBA'
+    )
   end
 end

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -20,4 +20,14 @@ EOF
 
     assert courses(:eecs482).get_group_string.strip == group_string.strip
   end
+
+  test "demo queue gets created with course" do
+    my_course = Course.create!(
+      name: 'test',
+      long_name: 'My Test Course',
+      slug: 'testcourse'
+    )
+
+    assert my_course.course_queues.count > 0, "Course create should also create a queue"
+  end
 end


### PR DESCRIPTION
A course without any queues is useless, and the UI looks strange without one too.