### PR TITLE
Don't display colon if long name is empty

### DIFF
--- a/app/views/courses/_courses.html.erb
+++ b/app/views/courses/_courses.html.erb
@@ -1,7 +1,7 @@
 <div class="ui massive fluid vertical menu">
     <% @courses.each do |course| %>
         <a href="<%= url_for course %>" class="item">
-            <strong><%= course.name %>:</strong> <%= course.long_name %>
+            <strong><%= course.name %><%= ':' if course.long_name.present? %></strong> <%= course.long_name %>
             <% if current_user.instructor_for_course?(course) %>
                 <div class="ui teal label">i</div>
             <% end %>


### PR DESCRIPTION
Just added a queue entry for a non-course that doesn't have a long name, and so shouldn't get a colon after the short name. The long name is not required and is not used anywhere else that I could find.