### PR TITLE
Add missing quotation marks

### DIFF
--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -36,7 +36,7 @@ class QueueChannel < ApplicationCable::Channel
       @course_queue.update_instructor_message!(data['message'])
 
       QueueChannel.broadcast_to(@course_queue, {
-          action: update_instructor_message,
+          action: 'update_instructor_message',
           message: data['message'],
       })
 


### PR DESCRIPTION
Closes #115.

I believe the missing quotation marks didn't allow the instructor message to be propagated via Action Cable. Without the quotation marks, the application behaves as described in issue #115. After adding the quotation marks, updates to the instructor message on save and broadcast work properly most of the time. When testing locally, occasionally updates to the instructor message (as well as other actions like enqueuing a new request, or going offline) will not propagate. This doesn't seem to be a problem with this specific feature (due to it affecting other actions not related to this one). I believe @mterwill and I discussed this to be a problem with the development setup.