### PR TITLE
Update broadcast message to make it less personal

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -75,7 +75,7 @@ var CourseQueue = React.createClass({
   },
   broadcastInstructorMessage: function (data) {
     if (this.props.currentUserId !== data.instructor.id){
-      this.notify(data.instructor.name + ' said:\n' + data.message, true,
+      this.notify(data.instructor.name + ' announced to the queue:\n' + data.message, true,
                   {icon: data.instructor.avatar_url});
     }
   },


### PR DESCRIPTION
Make the message more obvious that it is a broadcast to the queue, rather than a
personal message to someone specific on the queue.

Closes #114.