### PR TITLE
Add exclusive mode

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -245,7 +245,7 @@ var CourseQueue = React.createClass({
           cancelRequest={this.handler.cancelRequest.bind(this.handler)}
           updateRequest={this.handler.updateRequest.bind(this.handler)}
           myRequest={this.getMyFirstRequest()}
-          queueClosed={this.state.instructors.length <= 0}
+          queueClosed={!this.instructorsAvailable() || !this.userAuthorizedToEnqueue()}
           groupMode={this.props.groupMode}
         />
       );
@@ -286,6 +286,16 @@ var CourseQueue = React.createClass({
   getSegmentClass: function () {
     return this.state.enabled ?
       'ui min segment' : 'ui disabled loading min segment';
+  },
+  instructorsAvailable: function () {
+    return this.state.instructors.length > 0;
+  },
+  userAuthorizedToEnqueue: function () {
+    if (this.props.exclusiveMode) {
+      return this.props.courseGroupId != null || this.props.instructor;
+    } else {
+      return true;
+    }
   },
   renderRequestBox: function (title, requests, hideEmpty) {
     var myRequest = this.getMyFirstRequest();
@@ -341,7 +351,8 @@ var CourseQueue = React.createClass({
         </div>
         <QueueClosedMessage
           enabled={this.state.enabled}
-          instructors={this.state.instructors} />
+          userAuthorizedToEnqueue={this.userAuthorizedToEnqueue()}
+          instructorsAvailable={this.instructorsAvailable()} />
         <InstructorMessage
           enabled={this.state.enabled}
           instructors={this.state.instructors}

--- a/app/assets/javascripts/components/queue_closed_message.js.jsx
+++ b/app/assets/javascripts/components/queue_closed_message.js.jsx
@@ -1,10 +1,16 @@
 // TODO: actual messages
 var QueueClosedMessage = React.createClass({
   render: function () {
-    if (this.props.enabled && this.props.instructors.length <= 0) {
+    if (this.props.enabled && !this.props.instructorsAvailable) {
       return (
         <div className="sixteen wide column">
           <Message title="Queue Closed" message="The queue is now closed." id="queueClosed" />
+        </div>
+      )
+    } else if (this.props.enabled && !this.props.userAuthorizedToEnqueue) {
+      return (
+        <div className="sixteen wide column">
+          <Message title="Not Authorized" message="You are not authorized to use this queue." id="queueClosed" />
         </div>
       )
     } else {

--- a/app/controllers/admin/course_queues_controller.rb
+++ b/app/controllers/admin/course_queues_controller.rb
@@ -56,6 +56,6 @@ class Admin::CourseQueuesController < Admin::AdminController
   end
 
   def course_queue_params
-    params.require(:course_queue).permit(:name, :location, :description, :course_id, :group_mode)
+    params.require(:course_queue).permit(:name, :location, :description, :course_id, :group_mode, :exclusive)
   end
 end

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -11,6 +11,10 @@ class CourseQueue < ApplicationRecord
         raise "Limit one open request per user"
       end
 
+      if exclusive && group == nil && !requester.instructor_for_course_queue?(self)
+        raise "Only enrolled students may use this queue."
+      end
+
       # Now the group's
       count = outstanding_requests.where(course_group: group).count
       if group_mode && group && count > 0

--- a/app/views/admin/course_queues/_form.html.erb
+++ b/app/views/admin/course_queues/_form.html.erb
@@ -15,13 +15,22 @@
             <p>Import a list of groups for this course <a href="<%=
             groups_admin_course_url(@course_queue.course) %>">here</a>.</p>
         </div>
-        <div class="ui toggle checkbox">
-            <%= f.check_box :group_mode %>
-            <label>Enable course groups for this queue
-                <a href="https://github.com/mterwill/office-hours-help-queue/wiki/Group-mode">
-                    <i class="ui help circle grey icon"></i>
-                </a>
-            </label>
+        <div class="field">
+            <div class="ui toggle checkbox">
+                <%= f.check_box :group_mode %>
+                <label>Enable course groups for this queue
+                    <a href="https://github.com/mterwill/office-hours-help-queue/wiki/Group-mode">
+                        <i class="ui help circle grey icon"></i>
+                    </a>
+                </label>
+            </div>
+        </div>
+        <div class="field">
+            <div class="ui toggle checkbox">
+                <%= f.check_box :exclusive %>
+                <label>Only allow students in groups to enqueue
+                </label>
+            </div>
         </div>
     </div>
 

--- a/app/views/admin/courses/_queues.html.erb
+++ b/app/views/admin/courses/_queues.html.erb
@@ -3,6 +3,7 @@
         <tr><th style="width: 50%">Course Queue Name</th>
             <th style="width: 40%">Location</th>
             <th style="width: 10%">Group Mode</th>
+            <th style="width: 10%">Exclusive Mode</th>
             <th>
                 <a href="<%= new_admin_course_queue_path(@course) %>" class="ui primary labeled icon fluid button">
                     <i class="plus icon"></i>
@@ -17,6 +18,10 @@
                 <td><%= queue.location %></td>
                 <td><div class="ui disabled toggle checkbox">
                         <input type="checkbox" disabled="disabled" <%= 'checked' if queue.group_mode %>>
+                        <label></label>
+                    </div></td>
+                <td><div class="ui disabled toggle checkbox">
+                        <input type="checkbox" disabled="disabled" <%= 'checked' if queue.exclusive %>>
                         <label></label>
                     </div></td>
                 <td>

--- a/app/views/course_queues/show.html.erb
+++ b/app/views/course_queues/show.html.erb
@@ -14,6 +14,7 @@
           currentUserId={<%= current_user.id %>}
           courseGroupId={<%= @course_group_id %>}
           groupMode={<%= @course_queue.group_mode.to_s %>}
+          exclusiveMode={<%= @course_queue.exclusive.to_s %>}
           instructor={<%= @is_instructor %>}
           id={<%= @course_queue.id %>}
       />,

--- a/db/migrate/20181005025605_add_group_exclusive.rb
+++ b/db/migrate/20181005025605_add_group_exclusive.rb
@@ -1,0 +1,5 @@
+class AddGroupExclusive < ActiveRecord::Migration[5.0]
+  def change
+    add_column :course_queues, :exclusive, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170424200546) do
+ActiveRecord::Schema.define(version: 20181005025605) do
 
   create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "course_group_id", null: false
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 20170424200546) do
     t.datetime "updated_at",                                       null: false
     t.boolean  "group_mode",                       default: false, null: false
     t.text     "instructor_message", limit: 65535
+    t.boolean  "exclusive",                        default: false, null: false
     t.index ["course_id", "name"], name: "index_course_queues_on_course_id_and_name", unique: true, using: :btree
   end
 


### PR DESCRIPTION
eecs.help already has a [group mode][] that allows instructors to upload a comma and newline delimited list of students. When group mode is on for a queue, it restricts the number of simultaneous requests per group to 1. For example, the following would create two groups, each with three members:

```
bob@umich.edu,mary@umich.edu,sue@umich.edu
fred@umich.edu,randy@umich.edu,diane@umich.edu
```

However, if `sarah@umich.edu` came around, they would still be allowed to enqueue as they are not in any group. This was a design choice to allow students who may not have made it on the initial roster to  enqueue.

This PR adds "exclusive mode," which, when enabled, prevents users who are not listed in _any_ group for the current course from enqueueing. (e.g. `sarah@umich.edu`)

Note that exclusive mode and group mode are not mutually exclusive. This is because for each course you only have one list of students/groups, but many queues. For example, you may wish to always restrict your queues to authorized users. But only to enforce group mode on office hours for project help, but not exam help. 

When a student is not authorized to enqueue, they are placed into a r/o mode similar to when no instructors are online.

![image](https://user-images.githubusercontent.com/5882053/46514944-ecb2ed00-c82e-11e8-84b6-b145e02aa87d.png)

Exclusive mode is off by default. Closes #78.

[group mode]: https://github.com/mterwill/office-hours-help-queue/wiki/Group-mode