### PR TITLE
Implement not allowing multiple queue joins #116

### DIFF
--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -6,12 +6,9 @@ class CourseQueue < ApplicationRecord
 
   def request(requester:, description:, location:, group:)
     self.with_lock do
-      if self.course.course_queue_entries.where(resolved_at: nil).where(requester: requester).count > 0
+      # Check the user's request limit for the course
+      if self.course.course_queue_entries.where(resolved_at: nil, requester: requester).count > 0
           raise "Limit one open request per user"
-      end
-      # Check the user's request limit
-      if outstanding_requests.where(requester: requester).count > 0
-        raise "Limit one open request per user"
       end
 
       if exclusive && group == nil && !requester.instructor_for_course_queue?(self)

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -6,6 +6,9 @@ class CourseQueue < ApplicationRecord
 
   def request(requester:, description:, location:, group:)
     self.with_lock do
+      if self.course.course_queue_entries.where(resolved_at: nil).where(requester: requester).count > 0
+          raise "Limit one open request per user"
+      end
       # Check the user's request limit
       if outstanding_requests.where(requester: requester).count > 0
         raise "Limit one open request per user"


### PR DESCRIPTION
Prevents a student from being on multiple queues for the same course.

Doesn't handle on the frontend too well. Just doesn't submit the request. Better would be provide an error to the user that they are already in another queue. 

Alternatively, if they request being on a new queue, we could drop them from all other queues?