### PR TITLE
Sorting of queues based on number of previously resolved requests

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -233,7 +233,7 @@ var CourseQueue = React.createClass({
   },
   renderLeftPanel: function (columnClass) {
     var panel, instructorButton, studentButton, buttons;
- 
+
     if (this.props.instructor && this.state.instructorMode) {
       instructorButton = 'active';
       panel = (
@@ -365,6 +365,7 @@ var CourseQueue = React.createClass({
             courseName={this.props.courseName}
             queueName={this.props.queueName}
             queueLoc={this.props.queueLoc}
+            queueSorting={this.props.queueSorting}
           />
           <Instructors instructors={this.state.instructors} />
         </div>

--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -32,9 +32,11 @@ var CourseQueue = React.createClass({
   disable: function () {
     this.setState({ enabled: false });
   },
-  pushRequest: function (request) {
+  pushRequest: function (request, queue) {
     this.setState({
-      requests: this.state.requests.concat([request])
+      requests: this.state.requests.concat([request]).sort(function(a, b){
+        return queue.indexOf(a.id) - queue.indexOf(b.id);
+      })
     }, function () {
       var wasEmpty         = this.state.requests.length === 1;
       var isInactiveWindow = this.state.focused === false;
@@ -150,7 +152,7 @@ var CourseQueue = React.createClass({
       }.bind(this),
       received: function (data) {
         if (data.action === 'new_request') {
-          this.pushRequest(data.request);
+          this.pushRequest(data.request, data.queue);
         } else if (data.action === 'update_request') {
           this.updateRequest(data.request);
         } else if (data.action === 'resolve_request') {

--- a/app/assets/javascripts/components/header.js.jsx
+++ b/app/assets/javascripts/components/header.js.jsx
@@ -13,6 +13,9 @@ var Header = React.createClass({
         <div className="sub header">
           {this.props.queueName} {queueLoc}
         </div>
+        <div className="sub header">
+          <small>Sorting by {this.props.queueSorting}.</small>
+        </div>
       </h1>
     );
   },

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -143,6 +143,7 @@ class QueueChannel < ApplicationCable::Channel
     QueueChannel.broadcast_to(@course_queue, {
       action: action,
       request: serialize_request(request),
+      queue: serialize_queue_ids(@course_queue.outstanding_requests),
     })
   end
 

--- a/app/controllers/admin/course_queues_controller.rb
+++ b/app/controllers/admin/course_queues_controller.rb
@@ -1,7 +1,7 @@
 class Admin::CourseQueuesController < Admin::AdminController
   before_action :set_and_authorize_course, only: [:new]
   before_action :set_and_authorize_course_queue, except: [:new, :create]
-  
+
   def new
     @course_queue = CourseQueue.new
     @course_queue.course = @course

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -85,7 +85,7 @@ class Admin::CoursesController < Admin::AdminController
 
   private
   def course_params
-    params.require(:course).permit(:name, :long_name, :slug)
+    params.require(:course).permit(:name, :long_name, :slug, :sort_by)
   end
 
   def set_course

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -85,7 +85,7 @@ class Admin::CoursesController < Admin::AdminController
 
   private
   def course_params
-    params.require(:course).permit(:name, :long_name, :slug, :sort_by)
+    params.require(:course).permit(:name, :long_name, :slug, :sorting)
   end
 
   def set_course

--- a/app/helpers/course_queues_helper.rb
+++ b/app/helpers/course_queues_helper.rb
@@ -6,4 +6,8 @@ module CourseQueuesHelper
       resolver:  { except: User::PROTECTED_FIELDS }
     }})
   end
+
+  def serialize_queue_ids(queue)
+    queue.as_json(only: [:id])
+  end
 end

--- a/app/helpers/course_queues_helper.rb
+++ b/app/helpers/course_queues_helper.rb
@@ -8,6 +8,6 @@ module CourseQueuesHelper
   end
 
   def serialize_queue_ids(queue)
-    queue.as_json(only: [:id])
+    queue.as_json(only: [:id]).map { |entry| entry["id"] }
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,7 +6,7 @@ class Course < ApplicationRecord
   has_many :course_groups, dependent: :destroy
   has_many :instructors, through: :course_instructors
   has_many :course_queue_entries, through: :course_queues
-  enum sort_by: [:created_at, :resolved_requests_this_session]
+  enum sorting: [:timestamp, :number_of_resolved_requests_this_session]
 
   after_create :create_default_queue
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,6 +6,7 @@ class Course < ApplicationRecord
   has_many :course_groups, dependent: :destroy
   has_many :instructors, through: :course_instructors
   has_many :course_queue_entries, through: :course_queues
+  enum sort_by: [:created_at, :resolved_requests_this_session]
 
   after_create :create_default_queue
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,7 +6,7 @@ class Course < ApplicationRecord
   has_many :course_groups, dependent: :destroy
   has_many :instructors, through: :course_instructors
   has_many :course_queue_entries, through: :course_queues
-  enum sorting: [:timestamp, :number_of_resolved_requests_this_session]
+  enum sorting: [:timestamp, :number_of_resolved_requests_this_session], _prefix: :sort_by
 
   after_create :create_default_queue
 

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -40,12 +40,12 @@ class CourseQueue < ApplicationRecord
       .joins(<<-SQL
           LEFT JOIN (SELECT C.requester_id as pivot_r_id, COUNT(C.requester_id) AS cnt
           FROM course_queue_entries C
-          WHERE C.course_queue_id = #{id} AND C.course_group_id IS NULL
+          WHERE C.course_queue_id = #{id} AND C.course_group_id IS NULL AND C.resolver_id IS NOT NULL
           GROUP BY pivot_r_id) T on requester_id = T.pivot_r_id
         SQL
       )
       .where(resolved_at: nil)
-      .order("T.cnt ASC")
+      .order("T.cnt, created_at ASC")
     else
       course_queue_entries.where(resolved_at: nil).order('created_at ASC')
     end

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -35,7 +35,7 @@ class CourseQueue < ApplicationRecord
   end
 
   def outstanding_requests
-    if course.number_of_resolved_requests_this_session?
+    if course.sort_by_number_of_resolved_requests_this_session?
       if !course_queue_online_instructors.nil?
         # Find when queue openned
 

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -35,7 +35,7 @@ class CourseQueue < ApplicationRecord
   end
 
   def outstanding_requests
-    if course.resolved_requests_this_session?
+    if course.number_of_resolved_requests_this_session?
       if !course_queue_online_instructors.nil?
         # Find when queue openned
 

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -35,7 +35,7 @@ class CourseQueue < ApplicationRecord
   end
 
   def outstanding_requests
-    if course.sort_by
+    if course.resolved_requests_this_session?
       if !course_queue_online_instructors.nil?
         # Find when queue openned
 

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -35,7 +35,20 @@ class CourseQueue < ApplicationRecord
   end
 
   def outstanding_requests
-    course_queue_entries.where(resolved_at: nil).order('created_at ASC')
+    if course.sort_by
+      course_queue_entries.where(resolved_at: nil)
+      .order(<<-SQL
+              (
+                SELECT COUNT(requester_id)
+                FROM `course_queue_entries`
+                WHERE resolved_at IS NOT NULL
+                GROUP BY requester_id
+              ) ASC
+             SQL
+            )
+    else
+      course_queue_entries.where(resolved_at: nil).order('created_at ASC')
+    end
   end
 
   def update_instructor_message!(message)

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -14,5 +14,10 @@
         <%= f.text_field :slug %>
     </div>
 
+    <div class="field">
+        <%= f.label "Sort by number of previous resolved requests" %>
+        <%= f.check_box :sort_by %>
+    </div>
+
     <%= f.submit 'Submit', class: 'ui button' %>
 <% end %>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -15,11 +15,8 @@
     </div>
 
     <div class="field">
-        <div class="ui toggle checkbox">
-            <%= f.check_box :sort_by %>
-            <label>Sort by number of previously resolved requests over all time
-            </label>
-        </div>
+      <%= f.label :sorting %>
+       <%= f.select(:sorting, Course.sortings.keys.map {|sorting| [sorting.titleize,sorting]}) %>
     </div>
 
     <%= f.submit 'Submit', class: 'ui button' %>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -15,8 +15,11 @@
     </div>
 
     <div class="field">
-        <%= f.label "Sort by number of previous resolved requests" %>
-        <%= f.check_box :sort_by %>
+        <div class="ui toggle checkbox">
+            <%= f.check_box :sort_by %>
+            <label>Sort by number of previously resolved requests over all time
+            </label>
+        </div>
     </div>
 
     <%= f.submit 'Submit', class: 'ui button' %>

--- a/app/views/admin/courses/_sort.html.erb
+++ b/app/views/admin/courses/_sort.html.erb
@@ -1,0 +1,5 @@
+<% if @course.sort_by %>
+number of previous resolved requests
+<% else %>
+time request is created
+<% end %>

--- a/app/views/admin/courses/_sort.html.erb
+++ b/app/views/admin/courses/_sort.html.erb
@@ -1,4 +1,4 @@
-<% if @course.sort_by %>
+<% if @course.number_of_resolved_requests_this_session? %>
 number of previous resolved requests
 <% else %>
 time request is created

--- a/app/views/admin/courses/_sort.html.erb
+++ b/app/views/admin/courses/_sort.html.erb
@@ -1,4 +1,4 @@
-<% if @course.number_of_resolved_requests_this_session? %>
+<% if @course.sort_by_number_of_resolved_requests_this_session? %>
 number of previous resolved requests
 <% else %>
 time request is created

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -29,4 +29,7 @@
     <h2>Course Instructors</h2>
     <%= render 'self_enroll', code: @course.enrollment_code %>
     <%= render 'instructors', instructors: @instructors %>
+
+    <h2>Sort by</h2>
+    <%= render 'sort', course: @course %>
 </div>

--- a/app/views/course_queues/show.html.erb
+++ b/app/views/course_queues/show.html.erb
@@ -11,6 +11,7 @@
           courseName={"<%= j @course_queue.course.name.html_safe %>"}
           queueName={"<%= j @course_queue.name.html_safe %>"}
           queueLoc={"<%= j @course_queue.location.html_safe %>"}
+          queueSorting={"<%= j @course_queue.course.sorting.to_s.gsub('_',' ') %>"}
           currentUserId={<%= current_user.id %>}
           courseGroupId={<%= @course_group_id %>}
           groupMode={<%= @course_queue.group_mode.to_s %>}

--- a/db/migrate/20190426133610_add_course_sort_by.rb
+++ b/db/migrate/20190426133610_add_course_sort_by.rb
@@ -1,0 +1,5 @@
+class AddCourseSortBy < ActiveRecord::Migration[5.0]
+  def change
+    add_column :courses, :sort_by, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20190426133610_add_course_sort_by.rb
+++ b/db/migrate/20190426133610_add_course_sort_by.rb
@@ -1,5 +1,5 @@
 class AddCourseSortBy < ActiveRecord::Migration[5.0]
   def change
-    add_column :courses, :sort_by, :boolean, null: false, default: false
+    add_column :courses, :sort_by, :integer, null: false, default: 0
   end
 end

--- a/db/migrate/20190426133610_add_course_sort_by.rb
+++ b/db/migrate/20190426133610_add_course_sort_by.rb
@@ -1,5 +1,5 @@
 class AddCourseSortBy < ActiveRecord::Migration[5.0]
   def change
-    add_column :courses, :sort_by, :integer, null: false, default: 0
+    add_column :courses, :sorting, :integer, null: false, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 20190426133610) do
     t.string   "long_name",                  null: false
     t.string   "slug",                       null: false
     t.boolean  "archived",   default: false, null: false
-    t.integer  "sort_by",    default: 0,     null: false
+    t.integer  "sorting",    default: 0,     null: false
     t.index ["name"], name: "index_courses_on_name", unique: true, using: :btree
     t.index ["slug"], name: "index_courses_on_slug", unique: true, using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190426133610) do
+ActiveRecord::Schema.define(version: 20191110210519) do
 
   create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "course_group_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 20190426133610) do
     t.string   "long_name",                  null: false
     t.string   "slug",                       null: false
     t.boolean  "archived",   default: false, null: false
-    t.boolean  "sort_by",    default: false, null: false
+    t.integer  "sort_by",    default: 0,     null: false
     t.index ["name"], name: "index_courses_on_name", unique: true, using: :btree
     t.index ["slug"], name: "index_courses_on_slug", unique: true, using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191110210519) do
+ActiveRecord::Schema.define(version: 20190426133610) do
 
   create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "course_group_id", null: false
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 20191110210519) do
     t.string   "long_name",                  null: false
     t.string   "slug",                       null: false
     t.boolean  "archived",   default: false, null: false
+    t.boolean  "sort_by",    default: false, null: false
     t.index ["name"], name: "index_courses_on_name", unique: true, using: :btree
     t.index ["slug"], name: "index_courses_on_slug", unique: true, using: :btree
   end

--- a/test/fixtures/course_instructors.yml
+++ b/test/fixtures/course_instructors.yml
@@ -7,3 +7,7 @@ matt_eecs398:
 matt_eecs482:
   course: eecs482
   instructor: matt
+
+matt_eecs281:
+  course: eecs281
+  instructor: matt

--- a/test/fixtures/course_queues.yml
+++ b/test/fixtures/course_queues.yml
@@ -8,6 +8,14 @@ eecs398_queue:
   course: eecs398
   group_mode: false
 
+eecs281_sort_by_resolves_queue:
+  name: TA Office Hours
+  location: 1695 BBB
+  description: ''
+  is_open: true
+  course: eecs281
+  group_mode: false
+
 eecs482_group_queue:
   name: Project Help
   location: 1670 BBB

--- a/test/fixtures/course_queues.yml
+++ b/test/fixtures/course_queues.yml
@@ -8,7 +8,7 @@ eecs398_queue:
   course: eecs398
   group_mode: false
 
-eecs281_sort_by_resolves_queue:
+eecs281_sorting_resolves_queue:
   name: TA Office Hours
   location: 1695 BBB
   description: ''

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -1,5 +1,11 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+eecs281:
+  name: EECS 281
+  long_name: Data Structures & Algorithms
+  slug: eecs281
+  sort_by: true
+
 eecs398:
   name: EECS 398
   long_name: Computing for Computer Scientists

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -4,7 +4,7 @@ eecs281:
   name: EECS 281
   long_name: Data Structures & Algorithms
   slug: eecs281
-  sort_by: true
+  sort_by: 1
 
 eecs398:
   name: EECS 398

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -4,7 +4,7 @@ eecs281:
   name: EECS 281
   long_name: Data Structures & Algorithms
   slug: eecs281
-  sort_by: 1
+  sorting: 1
 
 eecs398:
   name: EECS 398

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -53,7 +53,7 @@ class CourseQueueTest < ActiveSupport::TestCase
   test "request are sorted by number of previously resolved requests" do
 
     assert @queue_sort.course_queue_entries.blank?
-    assert @queue_sort.course.sort_by
+    assert @queue_sort.course.resolved_requests_this_session?
 
     entry_sue_1 = @queue_sort.request(
       requester: users(:sue),

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -157,6 +157,45 @@ class CourseQueueTest < ActiveSupport::TestCase
     assert @queue_sort.outstanding_requests[1] == entry_sue_4
     assert @queue_sort.outstanding_requests[2] == entry_jim_4
 
+    # close queue and reopen, should "reset"
+    # need to sleep to make timestamps different
+    sleep(3)
+
+    @queue_sort.online_instructors.map { |i| i.sign_out!(@course_queue) }
+    @queue_sort.outstanding_requests.each do |request|
+      request.destroy!
+    end
+
+    assert @queue_sort.outstanding_requests.blank?
+
+    users(:matt).sign_in!(@queue_sort)
+
+    entry_steve_2_1 = @queue_sort.request(
+      requester: users(:steve),
+      description: 'steve 2_1',
+      location: '',
+      group: nil
+    )
+
+    entry_steve_2_1.resolve_by!(users(:matt))
+
+    entry_steve_2_2 = @queue_sort.request(
+      requester: users(:steve),
+      description: 'steve 2_2',
+      location: '',
+      group: nil
+    )
+
+    entry_sue_2_1 = @queue_sort.request(
+      requester: users(:sue),
+      description: 'sue 2_1',
+      location: '',
+      group: nil
+    )
+
+    assert @queue_sort.outstanding_requests[0] == entry_sue_2_1
+    assert @queue_sort.outstanding_requests[1] == entry_steve_2_2
+
   end
 
   test "request validates duplicates" do

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class CourseQueueTest < ActiveSupport::TestCase
   setup do
     @queue       = course_queues(:eecs398_queue)
-    @queue_sort  = course_queues(:eecs281_sort_by_resolves_queue)
+    @queue_sort  = course_queues(:eecs281_sorting_resolves_queue)
     @group_queue = course_queues(:eecs482_group_queue)
     @requester   = users(:matt)
   end
@@ -53,7 +53,7 @@ class CourseQueueTest < ActiveSupport::TestCase
   test "request are sorted by number of previously resolved requests" do
 
     assert @queue_sort.course_queue_entries.blank?
-    assert @queue_sort.course.resolved_requests_this_session?
+    assert @queue_sort.course.number_of_resolved_requests_this_session?
 
     entry_sue_1 = @queue_sort.request(
       requester: users(:sue),

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -53,7 +53,7 @@ class CourseQueueTest < ActiveSupport::TestCase
   test "request are sorted by number of previously resolved requests" do
 
     assert @queue_sort.course_queue_entries.blank?
-    assert @queue_sort.course.number_of_resolved_requests_this_session?
+    assert @queue_sort.course.sort_by_number_of_resolved_requests_this_session?
 
     entry_sue_1 = @queue_sort.request(
       requester: users(:sue),

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -142,6 +142,21 @@ class CourseQueueTest < ActiveSupport::TestCase
     assert @queue_sort.outstanding_requests[1] == entry_jim_3
     assert @queue_sort.outstanding_requests[2] == entry_sue_4
 
+    # On tie, sort by timestamp
+
+    entry_jim_3.resolve_by!(users(:matt))
+
+    entry_jim_4 = @queue_sort.request(
+      requester: users(:jim),
+      description: 'jim 4',
+      location: '',
+      group: nil
+    )
+
+    assert @queue_sort.outstanding_requests[0] == entry_steve_2
+    assert @queue_sort.outstanding_requests[1] == entry_sue_4
+    assert @queue_sort.outstanding_requests[2] == entry_jim_4
+
   end
 
   test "request validates duplicates" do


### PR DESCRIPTION
This PR would add the ability for a course to opt in for a course wide sorting of queues based on the number of previous resolved requests (resolved by timestamp on ties). Address issue #109.

Summary of changes:
- New sort attribute for courses.
- Sort attribute can be changed by admin on course edit page.
- If sort attribute is on, orders queue according to number of previous resolved requests for the course (and then by timestamp).
- Tests of the new feature.

Feedback would be great!