### PR TITLE
Add ability for users to set their own nickname

### DIFF
--- a/app/assets/javascripts/components/request.js.jsx
+++ b/app/assets/javascripts/components/request.js.jsx
@@ -23,6 +23,13 @@ var Request = React.createClass({
       ts: moment(this.props.request.created_at).fromNow(),
     });
   },
+  getRequesterNameString: function () {
+    if (this.props.request.requester.nickname) {
+      return `${this.props.request.requester.name} (${this.props.request.requester.nickname})`;
+    } else {
+      return this.props.request.requester.name;
+    }
+  },
   render: function () {
     var actions;
     if (this.props.resolve) {
@@ -57,7 +64,7 @@ var Request = React.createClass({
       <div className={active + "comment"}>
         <Avatar url={this.props.request.requester.avatar_url} />
         <div className="content">
-          <span className="author">{this.props.request.requester.name}</span>
+          <span className="author">{this.getRequesterNameString()}</span>
           <a ref={this.ref} href="" onClick={function (e) { e.preventDefault(); }}
              data-clipboard-text={this.props.request.requester.email}
              className="metadata">{this.props.request.requester.email}</a>

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,17 @@
+class SettingsController < ApplicationController
+  def edit
+  end
+
+  def save
+    if current_user.update(user_params)
+      redirect_to root_url
+    else
+      render :edit
+    end
+  end
+
+  private
+  def user_params
+    params.require(:user).permit(:nickname)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   PROTECTED_FIELDS = %w(oauth_token oauth_expires_at uid provider)
 
+  validates_length_of :nickname, maximum: 25, allow_blank: true
+
   def self.from_omniauth(auth)
     # TODO: we want to unique key on email here, but the provider/uid combo that
     # was here is more conducive to actual omniauth

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -13,6 +13,10 @@
         <p><strong>New course?</strong> Email <a href="mailto:newcourse@eecs.help">newcourse@eecs.help</a>.</p>
     </div>
 
+    <a class="ui large fluid button bottom padded" href="<%= url_for settings_path %>">
+        Settings
+    </a>
+
     <% if current_user.global_admin? %>
         <a class="ui large fluid primary button" href="<%= url_for admin_courses_path %>">
             Admin Panel

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,0 +1,20 @@
+<div class="six wide column">
+    <h1 class="ui header">
+        Edit settings
+    </h1>
+
+    <% current_user.errors.full_messages.each do |e| %>
+        <div class="ui error message">
+            <%= e %>
+        </div>
+    <% end %>
+
+    <%= form_tag({}, class: 'ui form') do |f| %>
+        <div class="field">
+            <%= label_tag :nickname %>
+            <%= text_field_tag 'user[nickname]', current_user.nickname %>
+        </div>
+
+        <%= submit_tag 'Submit', class: 'ui button' %>
+    <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
 
   resources :courses, only: [:index, :show]
 
+  get 'settings', to: 'settings#edit'
+  post 'settings', to: 'settings#save'
+
   namespace :admin do
     resources :course_queues, except: [:new, :show]
     resources :course_instructors, except: [:new, :show]

--- a/db/migrate/20191110210519_add_nickname.rb
+++ b/db/migrate/20191110210519_add_nickname.rb
@@ -1,0 +1,5 @@
+class AddNickname < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :nickname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191024175216) do
+ActiveRecord::Schema.define(version: 20191110210519) do
 
   create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "course_group_id", null: false
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 20191024175216) do
     t.string   "provider"
     t.string   "avatar_url",       limit: 1000
     t.boolean  "global_admin"
+    t.string   "nickname"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
   end
 


### PR DESCRIPTION
This feature was requested in #138. Because we pull the names from Google, there's no way for a user to change their display name.

This adds a 'Settings' page and corresponding link for users to edit settings specific to their account. Adding a nickname is the only thing on this page as of now.

<img width="1280" alt="Screen Shot 2019-11-10 at 4 49 32 PM" src="https://user-images.githubusercontent.com/5882053/68551359-29f69080-03da-11ea-8660-93654a3eeb22.png">

If a user has a nickname, it will show up in parenthesis next to their official name:

<img width="489" alt="image" src="https://user-images.githubusercontent.com/5882053/68551373-57433e80-03da-11ea-9e49-f007ad99edc9.png">
