### PR TITLE
Surface errors from invalid requests

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -159,6 +159,8 @@ var CourseQueue = React.createClass({
            this.notify(data.bump_by.name + ' is looking for you!', true, {
              icon: data.bump_by.avatar_url,
            });
+        } else if (data.action === 'invalid_request') {
+          alert('Invalid request: ' + data.error);
         }
       }.bind(this),
     });

--- a/app/models/course_queue.rb
+++ b/app/models/course_queue.rb
@@ -1,3 +1,6 @@
+class InvalidRequestError < StandardError
+end
+
 class CourseQueue < ApplicationRecord
   belongs_to :course
   has_many :course_queue_entries
@@ -8,17 +11,17 @@ class CourseQueue < ApplicationRecord
     self.with_lock do
       # Check the user's request limit for the course
       if self.course.course_queue_entries.where(resolved_at: nil, requester: requester).count > 0
-          raise "Limit one open request per user"
+          raise InvalidRequestError, "Limit one open request per user per course"
       end
 
       if exclusive && group == nil && !requester.instructor_for_course_queue?(self)
-        raise "Only enrolled students may use this queue."
+        raise InvalidRequestError, "Only enrolled students may use this queue."
       end
 
       # Now the group's
       count = outstanding_requests.where(course_group: group).count
       if group_mode && group && count > 0
-        raise "Limit one open request per group"
+        raise InvalidRequestError, "Limit one open request per group"
       end
 
       CourseQueueEntry.create!(

--- a/test/models/course_queue_test.rb
+++ b/test/models/course_queue_test.rb
@@ -50,7 +50,7 @@ class CourseQueueTest < ActiveSupport::TestCase
   end
 
   test "request validates duplicates" do
-    assert_raise RuntimeError do
+    assert_raise InvalidRequestError do
       2.times {
         @queue.request(
           requester: users(:steve),
@@ -103,7 +103,7 @@ class CourseQueueTest < ActiveSupport::TestCase
       group: course_groups(:group1)
     )
 
-    assert_raise RuntimeError do
+    assert_raise InvalidRequestError do
       @group_queue.request(
         requester: users(:matt),
         description: '',


### PR DESCRIPTION
These exceptions, previously uncaught, would not indicate any error on the client side, leading to a confusing behavior where requesting for help would appear to be broken. This provides some indication to the client of the issue.

Relates to #140.