### PR TITLE
Adding enhancement #131 - Student title vs. Instructor title 

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -9,6 +9,15 @@ var CourseQueue = React.createClass({
       instructorMessage: '',
     };
   },
+  updateTitle:function(){
+    var myRequest = this.getMyFirstRequest();
+    if (myRequest && this.state.requests.indexOf(myRequest.request) >= 0) {
+      var myRequestIdx = this.state.requests.indexOf(myRequest.request);
+      document.title = `(#${myRequestIdx + 1}) Office Hours Help Queue`
+    } else {
+      document.title = `(${this.state.requests.length}) Office Hours Help Queue`
+    }
+  },
   enable: function () {
     this.setState({ enabled: true });
   },
@@ -160,6 +169,7 @@ var CourseQueue = React.createClass({
              icon: data.bump_by.avatar_url,
            });
         }
+        this.updateTitle();
       }.bind(this),
     });
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>Office Hours Help Queue</title>
+        <title>481 Test</title>
         <%= csrf_meta_tags %>
 
         <%= stylesheet_link_tag    'application', media: 'all' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>481 Test</title>
+        <title>Office Hours Help Queue</title>
         <%= csrf_meta_tags %>
 
         <%= stylesheet_link_tag    'application', media: 'all' %>


### PR DESCRIPTION
This PR addresses the enhancement requested by issue #131 , and was made with Ram Natla (@ramnatla). If the logged-in user is currently on the queue, the title of the page is updated to show their position: "(#2) Office Hours Help Queue". If the logged-in user is not on the queue, the title will display the total number of people on the queue. For example, if 20 people were on the queue, the title will display: "(20) Office Hours Help Queue". 

To implement this, any time the queue receives an update, the title of the page was dynamically changed. 

We would appreciate any and all feedback on this PR!