### PR TITLE
Update request.js.jsx to redact google hangouts links

### DIFF
--- a/app/assets/javascripts/components/request.js.jsx
+++ b/app/assets/javascripts/components/request.js.jsx
@@ -60,6 +60,9 @@ var Request = React.createClass({
       );
     }
 
+	// temporary hack for descriptions containing google link
+	let description_redacted = this.props.request.description.includes("google") ? 'Google hangout links are private' : this.props.request.description
+
     return (
       <div className={active + "comment"}>
         <Avatar url={this.props.request.requester.avatar_url} />
@@ -71,7 +74,7 @@ var Request = React.createClass({
           <div className="ui slightly padded list">
             <LabeledItem icon="clock">{this.state.ts}</LabeledItem>
             <LabeledItem icon="marker">{this.props.request.location}</LabeledItem>
-            <LabeledItem icon="write">{this.props.request.description}</LabeledItem>
+            <LabeledItem icon="write">{description_redacted}</LabeledItem>
             {pinnedByUser}
           </div>
           {actions}


### PR DESCRIPTION
Hi @mterwill ! Thank you for maintaining the website. In 281 (and I believe in other classes) there's an ongoing issue of google hangout links being visible in the description box (allows unwanted parties access the link and close the hangouts link for instructors). This pull request is a bit of a hackish way to go around it, as it's not implemented in server and the check might be a false positive for a general google link (includes a comment regarding that)

Would you want this to be implemented server-side? I think this solution can work out temporarily and I'm not familiar with Ruby yet.

PS: This is only to address the recent adoption of online office hours due to the recent context.