### PR TITLE
Add option to hide details from other students

### DIFF
--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -139,6 +139,18 @@ class QueueChannel < ApplicationCable::Channel
   end
 
   private
+
+  # Unlike other public broadcast interfaces of ActionCable, the transmit method
+  # allows us to redact a request on the per-user level while using the same
+  # channel, e.g. sending instructors different data than students.
+  def transmit(data, via: nil)
+    if data.key?('request')
+      data['request'] = redact_request(data['request'], current_user)
+    end
+
+    super
+  end
+
   def broadcast_request_change(action, request)
     QueueChannel.broadcast_to(@course_queue, {
       action: action,

--- a/app/controllers/admin/course_queues_controller.rb
+++ b/app/controllers/admin/course_queues_controller.rb
@@ -56,6 +56,6 @@ class Admin::CourseQueuesController < Admin::AdminController
   end
 
   def course_queue_params
-    params.require(:course_queue).permit(:name, :location, :description, :course_id, :group_mode, :exclusive)
+    params.require(:course_queue).permit(:name, :location, :description, :course_id, :group_mode, :exclusive, :hide_details_from_students)
   end
 end

--- a/app/helpers/course_queues_helper.rb
+++ b/app/helpers/course_queues_helper.rb
@@ -2,8 +2,25 @@ module CourseQueuesHelper
   def serialize_request(request)
     request.as_json({
       include: {
-      requester: { except: User::PROTECTED_FIELDS },
-      resolver:  { except: User::PROTECTED_FIELDS }
-    }})
+        requester: { except: User::PROTECTED_FIELDS },
+        resolver:  { except: User::PROTECTED_FIELDS }
+      }
+    })
+  end
+
+  def redact_request(request_hash, current_user)
+    course_queue = CourseQueue.find(request_hash['course_queue_id'])
+
+    request_is_from_current_user = request_hash['requester_id'] == current_user.id
+    current_user_is_instructor = current_user.instructor_for_course_queue? course_queue
+    private_mode = course_queue.hide_details_from_students
+
+    should_redact = private_mode && !request_is_from_current_user && !current_user_is_instructor
+
+    if should_redact
+      return request_hash.except('location', 'description')
+    else
+      return request_hash
+    end
   end
 end

--- a/app/views/admin/course_queues/_form.html.erb
+++ b/app/views/admin/course_queues/_form.html.erb
@@ -32,6 +32,13 @@
                 </label>
             </div>
         </div>
+        <div class="field">
+            <div class="ui toggle checkbox">
+                <%= f.check_box :hide_details_from_students %>
+                <label>Private Mode</strong>: Hide request details (location, description) from other students
+                </label>
+            </div>
+        </div>
     </div>
 
     <%= f.hidden_field :course_id %>

--- a/app/views/admin/courses/_queues.html.erb
+++ b/app/views/admin/courses/_queues.html.erb
@@ -4,6 +4,7 @@
             <th style="width: 40%">Location</th>
             <th style="width: 10%">Group Mode</th>
             <th style="width: 10%">Exclusive Mode</th>
+            <th style="width: 10%">Private Mode</th>
             <th>
                 <a href="<%= new_admin_course_queue_path(@course) %>" class="ui primary labeled icon fluid button">
                     <i class="plus icon"></i>
@@ -22,6 +23,10 @@
                     </div></td>
                 <td><div class="ui disabled toggle checkbox">
                         <input type="checkbox" disabled="disabled" <%= 'checked' if queue.exclusive %>>
+                        <label></label>
+                    </div></td>
+                <td><div class="ui disabled toggle checkbox">
+                        <input type="checkbox" disabled="disabled" <%= 'checked' if queue.hide_details_from_students %>>
                         <label></label>
                     </div></td>
                 <td>

--- a/app/views/course_queues/outstanding_requests.json.jbuilder
+++ b/app/views/course_queues/outstanding_requests.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @outstanding_requests do |request|
-    json.merge! serialize_request(request)
+    json.merge! redact_request(serialize_request(request), current_user)
 end

--- a/db/migrate/20200312232645_add_hide_details_option.rb
+++ b/db/migrate/20200312232645_add_hide_details_option.rb
@@ -1,0 +1,5 @@
+class AddHideDetailsOption < ActiveRecord::Migration[5.0]
+  def change
+    add_column :course_queues, :hide_details_from_students, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191110210519) do
+ActiveRecord::Schema.define(version: 20200312232645) do
 
   create_table "course_group_students", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer "course_group_id", null: false
@@ -56,16 +56,17 @@ ActiveRecord::Schema.define(version: 20191110210519) do
   end
 
   create_table "course_queues", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
-    t.string   "name",                                             null: false
+    t.string   "name",                                                     null: false
     t.string   "location"
-    t.text     "description",        limit: 65535
+    t.text     "description",                limit: 65535
     t.boolean  "is_open"
-    t.integer  "course_id",                                        null: false
-    t.datetime "created_at",                                       null: false
-    t.datetime "updated_at",                                       null: false
-    t.boolean  "group_mode",                       default: false, null: false
-    t.text     "instructor_message", limit: 65535
-    t.boolean  "exclusive",                        default: false, null: false
+    t.integer  "course_id",                                                null: false
+    t.datetime "created_at",                                               null: false
+    t.datetime "updated_at",                                               null: false
+    t.boolean  "group_mode",                               default: false, null: false
+    t.text     "instructor_message",         limit: 65535
+    t.boolean  "exclusive",                                default: false, null: false
+    t.boolean  "hide_details_from_students",               default: false, null: false
     t.index ["course_id", "name"], name: "index_course_queues_on_course_id_and_name", unique: true, using: :btree
   end
 

--- a/test/fixtures/course_queues.yml
+++ b/test/fixtures/course_queues.yml
@@ -22,3 +22,12 @@ closed_queue:
   description: ''
   is_open: false
   course: eecs398
+
+private_mode_queue:
+  name: Private Mode
+  location: 1670 BBB
+  description: ''
+  is_open: true
+  course: eecs398
+  group_mode: false
+  hide_details_from_students: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -19,3 +19,11 @@ sue:
 steve:
   name: Steve Sue
   email: steve@umich.edu
+
+bob:
+  name: Bob Jones
+  email: bob@umich.edu
+
+jd:
+  name: JD
+  email: jd@umich.edu

--- a/test/helpers/course_queues_helper_test.rb
+++ b/test/helpers/course_queues_helper_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class CourseQueuesHelperTest  < ActionView::TestCase
+  test "private mode on" do
+    @queue = course_queues(:private_mode_queue)
+
+    bob_request = @queue.request(
+      requester: users(:bob),
+      description: 'shh',
+      location: 'super secret',
+      group: nil,
+    )
+
+    request_hash = serialize_request(bob_request)
+
+    assert_nil(
+      redact_request(request_hash, users(:jd))['description'],
+      "students cannot see other students request description in private mode"
+    )
+
+    assert_nil(
+      redact_request(request_hash, users(:jd))['location'],
+      "students cannot see other students request location in private mode"
+    )
+
+    assert_equal(
+      'shh',
+      redact_request(request_hash, users(:bob))['description'],
+      "students see their own description in private mode"
+    )
+
+    assert_equal(
+      'super secret',
+      redact_request(request_hash, users(:bob))['location'],
+      "students see their own location in private mode"
+    )
+
+    assert_equal(
+      'shh',
+      redact_request(request_hash, users(:matt))['description'],
+      "instructors see descriptions in private mode"
+    )
+
+    assert_equal(
+      'super secret',
+      redact_request(request_hash, users(:matt))['location'],
+      "instructors see locations in private mode"
+    )
+  end
+
+  test "private mode off" do
+    @queue = course_queues(:eecs398_queue)
+
+    bob_request = @queue.request(
+      requester: users(:bob),
+      description: 'shh',
+      location: 'super secret',
+      group: nil,
+    )
+
+    request_hash = serialize_request(bob_request)
+
+    assert_equal(
+      'shh',
+      redact_request(request_hash, users(:jd))['description'],
+      "students see other students request description in normal mode"
+    )
+
+    assert_equal(
+      'super secret',
+      redact_request(request_hash, users(:jd))['location'],
+      "students see other students request location in normal mode"
+    )
+  end
+end


### PR DESCRIPTION
#157 outlines a need to hide location/description details from students. There are a couple of long-standing issues (#55, #69) that outline a similar class of problem. There are two places where we transmit request data:

1) on initial page load, when a user fetches outstanding requests
2) via WebSocket, as events stream in

Any information hiding should be done on the server-side in both of these places. This is complicated by the fact that we want to show different users different information:

* The current user should always see their own request details.
* Students should not see other students request details if private mode is on.
* Instructors should always see all request details.

This PR implements a "private mode" toggleable on a per-queue basis that hides location and description from other students. It also establishes a pattern we can use to implement per-student anonymity at a later time.