### PR TITLE
Pass queue order to frontend when new requests are received

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -33,10 +33,12 @@ var CourseQueue = React.createClass({
     this.setState({ enabled: false });
   },
   pushRequest: function (request, queue) {
-    this.setState({
-      requests: this.state.requests.concat([request]).sort(function(a, b){
-        return queue.indexOf(a.id) - queue.indexOf(b.id);
-      })
+    this.setState(function (prevState) {
+      return {
+        requests: prevState.requests.concat([request]).sort((a, b) => {
+          return queue.indexOf(a.id) - queue.indexOf(b.id);
+        }),
+      };
     }, function () {
       var wasEmpty         = this.state.requests.length === 1;
       var isInactiveWindow = this.state.focused === false;

--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -32,9 +32,11 @@ var CourseQueue = React.createClass({
   disable: function () {
     this.setState({ enabled: false });
   },
-  pushRequest: function (request) {
+  pushRequest: function (request, queue) {
     this.setState({
-      requests: this.state.requests.concat([request])
+      requests: this.state.requests.concat([request]).sort(function(a, b){
+        return queue.indexOf(a.id) - queue.indexOf(b.id);
+      })
     }, function () {
       var wasEmpty         = this.state.requests.length === 1;
       var isInactiveWindow = this.state.focused === false;
@@ -150,7 +152,7 @@ var CourseQueue = React.createClass({
       }.bind(this),
       received: function (data) {
         if (data.action === 'new_request') {
-          this.pushRequest(data.request);
+          this.pushRequest(data.request, data.queue);
         } else if (data.action === 'update_request') {
           this.updateRequest(data.request);
         } else if (data.action === 'resolve_request') {

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -155,6 +155,7 @@ class QueueChannel < ApplicationCable::Channel
     QueueChannel.broadcast_to(@course_queue, {
       action: action,
       request: serialize_request(request),
+      queue: serialize_queue_ids(@course_queue.outstanding_requests),
     })
   end
 

--- a/app/helpers/course_queues_helper.rb
+++ b/app/helpers/course_queues_helper.rb
@@ -23,4 +23,8 @@ module CourseQueuesHelper
       return request_hash
     end
   end
+
+  def serialize_queue_ids(queue)
+    queue.as_json(only: [:id])
+  end
 end

--- a/app/helpers/course_queues_helper.rb
+++ b/app/helpers/course_queues_helper.rb
@@ -25,6 +25,6 @@ module CourseQueuesHelper
   end
 
   def serialize_queue_ids(queue)
-    queue.as_json(only: [:id])
+    queue.as_json(only: [:id]).map { |entry| entry["id"] }
   end
 end


### PR DESCRIPTION
Currently, new requests are naively appended to the request list in the order that they are received. This PR serializes the canonical queue order and sorts the frontend accordingly.

Cherry picked from #136 for #148.

cc @MiloATH