### PR TITLE
Update private mode to respect course groups

### DIFF
--- a/app/helpers/course_queues_helper.rb
+++ b/app/helpers/course_queues_helper.rb
@@ -15,7 +15,16 @@ module CourseQueuesHelper
     current_user_is_instructor = current_user.instructor_for_course_queue? course_queue
     private_mode = course_queue.hide_details_from_students
 
-    should_redact = private_mode && !request_is_from_current_user && !current_user_is_instructor
+    request_is_from_same_group = false
+    if course_queue.group_mode && request_hash['course_group_id']
+      group = CourseGroup.find(request_hash['course_group_id'])
+      request_is_from_same_group = group.students.include? current_user
+    end
+
+    should_redact = private_mode &&
+      !request_is_from_current_user &&
+      !request_is_from_same_group &&
+      !current_user_is_instructor
 
     if should_redact
       return request_hash.except('location', 'description')

--- a/test/fixtures/course_groups.yml
+++ b/test/fixtures/course_groups.yml
@@ -14,3 +14,10 @@ group2:
 
 group3:
   course: eecs398
+
+group4:
+  course: eecs398
+  students:
+    - bob
+    - jim
+    - mary

--- a/test/fixtures/course_queues.yml
+++ b/test/fixtures/course_queues.yml
@@ -31,3 +31,12 @@ private_mode_queue:
   course: eecs398
   group_mode: false
   hide_details_from_students: true
+
+private_and_group_queue:
+  name: Private and Group Mode
+  location: 1670 BBB
+  description: ''
+  is_open: true
+  course: eecs398
+  group_mode: true
+  hide_details_from_students: true

--- a/test/helpers/course_queues_helper_test.rb
+++ b/test/helpers/course_queues_helper_test.rb
@@ -8,7 +8,7 @@ class CourseQueuesHelperTest  < ActionView::TestCase
       requester: users(:bob),
       description: 'shh',
       location: 'super secret',
-      group: nil,
+      group: course_groups(:group4),
     )
 
     request_hash = serialize_request(bob_request)
@@ -21,6 +21,16 @@ class CourseQueuesHelperTest  < ActionView::TestCase
     assert_nil(
       redact_request(request_hash, users(:jd))['location'],
       "students cannot see other students request location in private mode"
+    )
+
+    assert_nil(
+      redact_request(request_hash, users(:mary))['description'],
+      "students in the same group cannot see others description if group mode is off"
+    )
+
+    assert_nil(
+      redact_request(request_hash, users(:mary))['location'],
+      "students in the same group cannot see others location if group mode is off"
     )
 
     assert_equal(
@@ -45,6 +55,41 @@ class CourseQueuesHelperTest  < ActionView::TestCase
       'super secret',
       redact_request(request_hash, users(:matt))['location'],
       "instructors see locations in private mode"
+    )
+  end
+
+  test "private mode on with groups" do
+    @queue = course_queues(:private_and_group_queue)
+
+    jim_request = @queue.request(
+      requester: users(:jim),
+      description: 'shh',
+      location: 'super secret',
+      group: course_groups(:group4),
+    )
+
+    request_hash = serialize_request(jim_request)
+
+    assert_nil(
+      redact_request(request_hash, users(:jd))['description'],
+      "students not in the same group cannot see the description"
+    )
+
+    assert_nil(
+      redact_request(request_hash, users(:jd))['location'],
+      "students not in the same group cannot see the location"
+    )
+
+    assert_equal(
+      'shh',
+      redact_request(request_hash, users(:mary))['description'],
+      "students in the same group see the location"
+    )
+
+    assert_equal(
+      'super secret',
+      redact_request(request_hash, users(:mary))['location'],
+      "students in the same group see the description"
     )
   end
 


### PR DESCRIPTION
If group mode is on, students should be able to see the details of
requests in the same group.

Fixes #163