### PR TITLE
env was removed in Rails 5.1

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@ class SessionsController < ApplicationController
   skip_before_action :authenticate_user!
 
   def create
-    user = User.from_omniauth(env['omniauth.auth'])
+    user = User.from_omniauth(request.env['omniauth.auth'])
     cookies.signed[:user_id] = user.id
     redirect_to request.env['omniauth.origin'] || root_path
   end


### PR DESCRIPTION
#180 upgraded to Rails 5.1. Login is currently broken as direct access to `env` was removed in Rails 5.1. I did not catch this issue in testing as I was already logged in.

```
undefined local variable or method `env' for #<SessionsController:0x00000000021a8ea0>
```