### PR TITLE
Notify or raise deprecation warnings

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,6 @@ Rails.application.configure do
   Rails.application.config.action_cable.allowed_request_origins = ['http://dev.eecs.help:3000']
 
   config.web_console.whitelisted_ips = '172.18.0.1' # docker
+
+  config.active_support.deprecation = :raise
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,6 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   Rails.application.config.action_cable.allowed_request_origins = [ENV['FULL_HOST']]
+
+  config.active_support.deprecation = :notify
 end

--- a/config/initializers/deprecation_warnings.rb
+++ b/config/initializers/deprecation_warnings.rb
@@ -1,0 +1,6 @@
+ActiveSupport::Notifications.subscribe('deprecation.rails') do |_name, _start, _finish, _id, payload|
+  e = RuntimeError.new(payload[:message])
+  Bugsnag.notify(e, {:severity => "warning"}) do |report|
+    report.meta_data[:callstack] = payload[:callstack]
+  end
+end


### PR DESCRIPTION
To ease the process of upgrading Rails, notify Bugsnag on deprecated use in prod, and raise an exception in dev.