### PR TITLE
Add gems required for deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,8 @@ group :development do
   gem 'capistrano-rails',   '~> 1.2.0', require: false
   gem 'capistrano-bundler', '~> 1.2.0', require: false
   gem 'capistrano3-puma',   '~> 1.2.1', require: false
+
+  # https://github.com/net-ssh/net-ssh/issues/565
+  gem 'ed25519', '>= 1.2', '< 1.3', require: false
+  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
+    bcrypt_pbkdf (1.0.1)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     bugsnag (6.11.1)
@@ -85,6 +86,7 @@ GEM
     connection_pool (2.2.2)
     crass (1.0.6)
     debug_inspector (0.0.3)
+    ed25519 (1.2.4)
     erubi (1.9.0)
     execjs (2.7.0)
     faraday (0.15.4)
@@ -235,6 +237,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   bootsnap (~> 1.4.8)
   bugsnag (~> 6.11)
   byebug (~> 9.0.5)
@@ -244,6 +247,7 @@ DEPENDENCIES
   capistrano-rvm (~> 0.1.2)
   capistrano3-puma (~> 1.2.1)
   coffee-rails (~> 4.2)
+  ed25519 (>= 1.2, < 1.3)
   jbuilder (~> 2.6.0)
   jquery-rails (~> 4.2.1)
   listen (~> 3.0.5)


### PR DESCRIPTION
Include new gems required for deployment. Was previously failing with:

	/usr/local/bundle/gems/net-ssh-5.2.0/lib/net/ssh/authentication/ed25519_loader.rb:21:in `raiseUnlessLoaded': OpenSSH keys only supported if ED25519 is available (NotImplementedError)
	net-ssh requires the following gems for ed25519 support:
	 * ed25519 (>= 1.2, < 2.0)

See https://github.com/net-ssh/net-ssh/issues/565 for more information.