### PR TITLE
Update dev redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,4 @@ You will need [Docker](https://docker.com) installed.
 script/setup
 ```
 
-Now add an entry for `dev.eecs.help` to `127.0.0.1` in your `/etc/hosts` file.
-Google OAuth2 behaves a little weirdly when the callback URI is `localhost`.
-
-The app should now be accessible at http://dev.eecs.help:3000.
+The app should now be accessible at http://127.0.0.1:3000.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  Rails.application.config.action_cable.allowed_request_origins = ['http://dev.eecs.help:3000']
+  Rails.application.config.action_cable.allowed_request_origins = ['http://127.0.0.1:3000']
 
   config.web_console.whitelisted_ips = '172.18.0.1' # docker
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,6 @@
 OmniAuth.config.logger = Rails.logger
 
-OmniAuth.config.full_host = Rails.env.production? ? ENV['FULL_HOST'] : 'http://dev.eecs.help:3000'
+OmniAuth.config.full_host = Rails.env.production? ? ENV['FULL_HOST'] : 'http://127.0.0.1:3000'
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   if Rails.env.production?


### PR DESCRIPTION
Google is phasing out non-localhost plaintext HTTP redirect URIs for
OAuth2. See https://developers.google.com/identity/protocols/oauth2/policies#secure-response-handling.