### PR TITLE
Add queue randomization (#147)

### DIFF
--- a/app/assets/javascripts/components/course_queue.js.jsx
+++ b/app/assets/javascripts/components/course_queue.js.jsx
@@ -264,6 +264,7 @@ var CourseQueue = React.createClass({
           queues={this.state.queues}
           queuePop={this.handler.queuePop.bind(this.handler)}
           emptyQueue={this.handler.emptyQueue.bind(this.handler)}
+          randomizeQueue={this.handler.randomizeQueue.bind(this.handler)}
           mergeQueue={this.handler.mergeQueue.bind(this.handler)}
           setInstructorStatus={this.handler.setInstructorStatus.bind(this.handler)}
           takeQueueOffline={this.handler.takeQueueOffline.bind(this.handler)}

--- a/app/assets/javascripts/components/course_queue_client_action_handler.js
+++ b/app/assets/javascripts/components/course_queue_client_action_handler.js
@@ -26,6 +26,10 @@ CourseQueueClientActionHandler.prototype.emptyQueue = function () {
   this.subscription.perform('empty_queue');
 };
 
+CourseQueueClientActionHandler.prototype.randomizeQueue = function () {
+  this.subscription.perform('randomize_queue');
+};
+
 CourseQueueClientActionHandler.prototype.bump = function (requestId, message) {
   this.subscription.perform('bump', {
     id: requestId,

--- a/app/assets/javascripts/components/instructor_panel.js.jsx
+++ b/app/assets/javascripts/components/instructor_panel.js.jsx
@@ -40,8 +40,6 @@ var InstructorPanel = React.createClass({
       action: function () {
         if (confirm('Are you sure? This will randomize ' + this.props.queueLength + ' request(s).')) {
           this.props.randomizeQueue();
-          this.props.broadcastInstructorMessage('broadcast_instructor_message',
-            'An instructor has randomized the order of the queue'); // TODO: TEST
         }
       }.bind(this),
     };

--- a/app/assets/javascripts/components/instructor_panel.js.jsx
+++ b/app/assets/javascripts/components/instructor_panel.js.jsx
@@ -33,6 +33,17 @@ var InstructorPanel = React.createClass({
     };
 
   },
+  randomizeQueueButtonData: function () {
+    return {
+      title: 'Randomize Queue',
+      className: this.buttonBaseClass + "large " + (this.props.queueLength <= 0 ? "disabled" : ""),
+      action: function () {
+        if (confirm('Are you sure? This will randomize ' + this.props.queueLength + ' request(s).')) {
+          this.props.randomizeQueue();
+        }
+      }.bind(this),
+    };
+  },
   mergeQueueItem: function (queue) {
     var click = function () {
       if (confirm('Are you sure? This will permanently merge ' + this.props.queueLength
@@ -66,6 +77,7 @@ var InstructorPanel = React.createClass({
         <Action data={this.getInstructorToggleButtonData()} />
         <Action data={this.getTakeQueueOfflineButtonData()} />
         <Action data={this.emptyQueueButtonData()} />
+        <Action data={this.randomizeQueueButtonData()} />
         { mergeOptions.length > 0 && <div className="ui bottom padded fluid large menu">
           <div className="ui fluid simple dropdown item">
             Merge Into Queue

--- a/app/assets/javascripts/components/instructor_panel.js.jsx
+++ b/app/assets/javascripts/components/instructor_panel.js.jsx
@@ -40,6 +40,8 @@ var InstructorPanel = React.createClass({
       action: function () {
         if (confirm('Are you sure? This will randomize ' + this.props.queueLength + ' request(s).')) {
           this.props.randomizeQueue();
+          this.props.broadcastInstructorMessage('broadcast_instructor_message',
+            'An instructor has randomized the order of the queue'); // TODO: TEST
         }
       }.bind(this),
     };

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -120,6 +120,13 @@ class QueueChannel < ApplicationCable::Channel
     end
   end
 
+  def randomize_queue(data)
+    authorize :instructor_only 
+
+    # @course_queue.outstanding_requests
+    # TODO: Randomize the order of the outstanding_requests
+  end
+
   def instructor_status_toggle(data)
     authorize :instructor_only
 

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -123,8 +123,7 @@ class QueueChannel < ApplicationCable::Channel
   def randomize_queue(data)
     authorize :instructor_only 
 
-    # @course_queue.outstanding_requests
-    # TODO: Randomize the order of the outstanding_requests
+    @course_queue.outstanding_requests.shuffle # TODO: TEST
   end
 
   def instructor_status_toggle(data)

--- a/app/channels/queue_channel.rb
+++ b/app/channels/queue_channel.rb
@@ -123,7 +123,11 @@ class QueueChannel < ApplicationCable::Channel
   def randomize_queue(data)
     authorize :instructor_only 
 
-    @course_queue.outstanding_requests.shuffle # TODO: TEST
+    @course_queue.shuffle!
+    QueueChannel.broadcast_to(@course_queue, {
+      action: 'reorder_queue',
+      queue: serialize_queue_ids(@course_queue.outstanding_requests),
+    })
   end
 
   def instructor_status_toggle(data)

--- a/db/migrate/20211117160222_add_priority_to_course_queue_entry.rb
+++ b/db/migrate/20211117160222_add_priority_to_course_queue_entry.rb
@@ -1,0 +1,5 @@
+class AddPriorityToCourseQueueEntry < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_queue_entries, :priority, :integer, :default => 0, :null => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_12_232645) do
+ActiveRecord::Schema.define(version: 2021_11_17_160222) do
 
   create_table "course_group_students", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "course_group_id", null: false
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_03_12_232645) do
     t.datetime "updated_at", null: false
     t.string "location"
     t.integer "course_group_id"
+    t.integer "priority", default: 0, null: false
     t.index ["course_queue_id"], name: "index_course_queue_entries_on_course_queue_id"
   end
 


### PR DESCRIPTION
Add queue randomization as suggested in #147. 

I am having a bit of trouble setting up the server locally to test my changes, as I am getting 

>ActiveRecord::PendingMigrationError
Migrations are pending. To resolve this issue, run: bin/rails db:migrate RAILS_ENV=development

but I figured I would open this PR to get some feedback, and to see if I could get help with testing and a couple questions I had. I am currently unsure about two changes:

1) I am not familiar at all with  ruby, so I am guessing the way you shuffle the outstanding requests is by doing `@course_queue.outstanding_requests.shuffle` ([code here](https://github.com/mterwill/office-hours-help-queue/pull/207/files#diff-2f2e9f0a48ea80906d8bd5482db99a611b2640ff6b5735485da5306738232393R126)), but again I haven't been able to test this, and I am not sure if there are other metadata which also need to be shuffled around.

2) I am not positive if calling `course_queue`'s `broadcastInstructorMessage` from `instructor_panel` will work ([code here](https://github.com/mterwill/office-hours-help-queue/pull/207/files#diff-12f97d7cdbf3e8b96b2d1a746613ff4e6e330bd6978ff4da0679d833385551cfR43)). My intention is to send a notification to students whenever the queue is randomized.

Thanks for any help anyone can provide!