### PR TITLE
Pretty Print Timestamps in Statistics Page

### DIFF
--- a/app/views/admin/courses/_recent_request_stats.html.erb
+++ b/app/views/admin/courses/_recent_request_stats.html.erb
@@ -13,15 +13,15 @@
         </thead>
         <tbody>
             <% requests.each do |request| %>
-                <tr>
-                    <td> <%= request.requester.name %> (<%= request.requester.email.split('@')[0] %>)<br /> at <%= request.created_at %> </td>
+                <tr> 
+                    <td> <%= request.requester.name %> (<%= request.requester.email.split('@')[0] %>)<br /> at <%= request.created_at.in_time_zone("Eastern Time (US & Canada)").strftime("%r %b %d %Y %Z") %></td>
                 <td><%= request.course_queue.name %></td>
                 <td>
                     <strong>Location:</strong> <%= request.location.present? ? request.location : "N/A" %><br />
                     <strong>Description:</strong> <%= request.description.present? ? request.description : "N/A" %>
             </td>
             <td>
-                <%= request.resolver.name %> (<%= request.resolver.email.split('@')[0] %>)<br /> at <%= request.resolved_at %>
+                <%= request.resolver.name %> (<%= request.resolver.email.split('@')[0] %>)<br /> at <%= request.resolved_at.in_time_zone("Eastern Time (US & Canada)").strftime("%r %b %d %Y %Z") %>
         </td>
                 </tr>
             <% end %>

--- a/app/views/admin/courses/_recent_request_stats.html.erb
+++ b/app/views/admin/courses/_recent_request_stats.html.erb
@@ -13,7 +13,7 @@
         </thead>
         <tbody>
             <% requests.each do |request| %>
-                <tr> 
+                <tr>
                     <td> <%= request.requester.name %> (<%= request.requester.email.split('@')[0] %>)<br /> at <%= request.created_at.in_time_zone("Eastern Time (US & Canada)").strftime("%r %b %d %Y %Z") %></td>
                 <td><%= request.course_queue.name %></td>
                 <td>


### PR DESCRIPTION
This pull request implements the functionality of #82.

Time strings have been switched to display in EDT (Eastern Time) from UTC, as well as being displayed in a more readable format.

Attempting to have the time displayed in the user's local timezone via the ruby ".localtime" function always resulted in UTC being displayed, so we set it to display in EDT as a compromise.

Original Format:
![image](https://user-images.githubusercontent.com/23582602/164851096-4a88d25a-815e-4b2f-8c58-04d03f0adcb3.png)

New Format:
![image](https://user-images.githubusercontent.com/23582602/164851280-24c78141-0e6c-4790-8979-e4707599d999.png)
