### PR TITLE
Client-Side Autoclicker Defense Implementation

### DIFF
--- a/app/assets/javascripts/components/student_panel.js.jsx
+++ b/app/assets/javascripts/components/student_panel.js.jsx
@@ -3,6 +3,7 @@ var StudentPanel = React.createClass({
     return {
       myRequest: this.getState(this.props.myRequest),
       editMode: false,
+      disabled: false,
     };
   },
   componentWillReceiveProps: function (nextProps) {
@@ -30,9 +31,22 @@ var StudentPanel = React.createClass({
     });
   },
   requestHelp: function () {
-    this.props.requestHelp({
-      location: this.state.myRequest.location,
-      description: this.state.myRequest.description,
+    if(!this.state.disabled){
+      this.props.requestHelp({
+        location: this.state.myRequest.location,
+        description: this.state.myRequest.description,
+      });
+  
+      this.setState({
+        disabled: true
+      });
+  
+      setTimeout(this.enableButton, 10000);
+    }
+  },
+  enableButton: function() {
+    this.setState({
+      disabled: false
     });
   },
   cancelRequest: function () {
@@ -63,17 +77,32 @@ var StudentPanel = React.createClass({
         </div>
       );
     } else {
-      if (this.props.queueClosed) {
-        var btnClass = "ui disabled fluid button";
-      } else {
-        var btnClass = "ui fluid button";
-      }
 
-      return (
-        <div onClick={this.requestHelp} className={btnClass} tabIndex="0">
-          Request Help
-        </div>
-      );
+      // Three conditionals for three states including helpful text describing state
+      if (this.props.queueClosed) {
+          var btnClass = "ui basic fluid button"; 
+          return (
+            <div onClick={this.requestHelp} className={btnClass} tabIndex="0">
+              Queue Closed
+            </div>
+          );      
+      }
+      else if (this.state.disabled){
+          var btnClass = "ui disabled fluid button";
+          return (
+            <div onClick={this.requestHelp} className={btnClass} tabIndex="0">
+              Recently pressed... wait to join queue
+            </div>
+          );
+      }
+      else{
+          var btnClass = "ui fluid button";
+          return (
+            <div onClick={this.requestHelp} className={btnClass} tabIndex="0">
+              Request Help
+            </div>
+          );
+      }
     }
   },
   render: function () {


### PR DESCRIPTION
This pull request implements a fix to the issue presented in #147 (Queue sign-ups vulnerable to exploitation by auto clickers).

The idea behind this change is that the reason students are currently able to use an auto clicker to attempt to join the queue is that the button remains accessible while the queue is closed and that there is no penalty associated with clicking on the button while the queue is closed.

We created three states for the “Request Help” button: “Queue Closed”, Disabled, and Active. During “Queue Closed”, the button is active but is shown in a state which suggests to the user that it cannot be interacted with quite yet. Any button clicks while the queue is closed start a timer that disallows students from joining the queue for 10 seconds. This effectively stops students from either using auto clickers or spamming the location of the button manually.

This implementation effectively penalizes students for preemptively attempting to join the queue but does not affect students who simply click join when the queue opens.