### PR TITLE
Optionally add jitter to initial requests

### DIFF
--- a/app/controllers/admin/course_queues_controller.rb
+++ b/app/controllers/admin/course_queues_controller.rb
@@ -1,7 +1,7 @@
 class Admin::CourseQueuesController < Admin::AdminController
   before_action :set_and_authorize_course, only: [:new]
   before_action :set_and_authorize_course_queue, except: [:new, :create]
-  
+
   def new
     @course_queue = CourseQueue.new
     @course_queue.course = @course
@@ -56,6 +56,6 @@ class Admin::CourseQueuesController < Admin::AdminController
   end
 
   def course_queue_params
-    params.require(:course_queue).permit(:name, :location, :description, :course_id, :group_mode, :exclusive, :hide_details_from_students)
+    params.require(:course_queue).permit(:name, :location, :description, :course_id, :group_mode, :exclusive, :hide_details_from_students, :add_requested_at_jitter)
   end
 end

--- a/app/views/admin/course_queues/_form.html.erb
+++ b/app/views/admin/course_queues/_form.html.erb
@@ -35,7 +35,14 @@
         <div class="field">
             <div class="ui toggle checkbox">
                 <%= f.check_box :hide_details_from_students %>
-                <label>Private Mode</strong>: Hide request details (location, description) from other students
+                <label><strong>Private Mode</strong>: Hide request details (location, description) from other students
+                </label>
+            </div>
+        </div>
+        <div class="field">
+            <div class="ui toggle checkbox">
+                <%= f.check_box :add_requested_at_jitter %>
+                <label><strong>Jitter (beta)</strong>: For the first minute a queue is open, randomize requested_at timestamp by ±10 seconds
                 </label>
             </div>
         </div>

--- a/app/views/admin/courses/_queues.html.erb
+++ b/app/views/admin/courses/_queues.html.erb
@@ -5,6 +5,7 @@
             <th style="width: 10%">Group Mode</th>
             <th style="width: 10%">Exclusive Mode</th>
             <th style="width: 10%">Private Mode</th>
+            <th style="width: 10%">Jitter</th>
             <th>
                 <a href="<%= new_admin_course_queue_path(@course) %>" class="ui primary labeled icon fluid button">
                     <i class="plus icon"></i>
@@ -27,6 +28,10 @@
                     </div></td>
                 <td><div class="ui disabled toggle checkbox">
                         <input type="checkbox" disabled="disabled" <%= 'checked' if queue.hide_details_from_students %>>
+                        <label></label>
+                    </div></td>
+                <td><div class="ui disabled toggle checkbox">
+                        <input type="checkbox" disabled="disabled" <%= 'checked' if queue.add_requested_at_jitter %>>
                         <label></label>
                     </div></td>
                 <td>

--- a/app/views/admin/courses/show.html.erb
+++ b/app/views/admin/courses/show.html.erb
@@ -3,7 +3,7 @@
     'Admin'
 ] %>
 
-<div class="ten wide column">
+<div class="twelve wide column">
     <h1 class="ui header">
         <%= @course.name %>
         Course Administration

--- a/db/migrate/20220519123402_jitter.rb
+++ b/db/migrate/20220519123402_jitter.rb
@@ -1,0 +1,5 @@
+class Jitter < ActiveRecord::Migration[5.2]
+  def change
+    add_column :course_queues, :add_requested_at_jitter, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_12_232645) do
+ActiveRecord::Schema.define(version: 2022_05_19_123402) do
 
   create_table "course_group_students", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
     t.integer "course_group_id", null: false
@@ -67,6 +67,7 @@ ActiveRecord::Schema.define(version: 2020_03_12_232645) do
     t.text "instructor_message"
     t.boolean "exclusive", default: false, null: false
     t.boolean "hide_details_from_students", default: false, null: false
+    t.boolean "add_requested_at_jitter", default: false, null: false
     t.index ["course_id", "name"], name: "index_course_queues_on_course_id_and_name", unique: true
   end
 

--- a/test/fixtures/course_queues.yml
+++ b/test/fixtures/course_queues.yml
@@ -16,6 +16,14 @@ eecs482_group_queue:
   course: eecs482
   group_mode: true
 
+eecs482_jitter_queue:
+  name: Jitter
+  location: 1670 BBB
+  description: ''
+  is_open: true
+  course: eecs482
+  add_requested_at_jitter: true
+
 closed_queue:
   name: I am not real
   location: Nowhere


### PR DESCRIPTION
There have been many reports over the years of students who script clicking of 'request help' so they land on the top of the queue when it first opens. Those without are left at the bottom of the queue, potentially waiting hours for help.

This adds an opt-in feature to scramble the request timestamp by +/- 10 seconds during the first minute a queue is open. It is:

* implemented entirely server-side, hopefully minimizing gameability
* automatic when enabled, so instructors can set it and forget it
* more-or-less transparent to students, though they may notice their
  queue position change during the first minute

Hopefully this is enough to remove the edge for those using scripts and level the field. I marked the toggle as 'beta'; we can iterate on the approach depending on what instructors find in practice.