### PR TITLE
Wrap, rather than truncate location/description

### DIFF
--- a/app/assets/javascripts/components/labeled_item.js.jsx
+++ b/app/assets/javascripts/components/labeled_item.js.jsx
@@ -8,7 +8,7 @@ var LabeledItem = React.createClass({
       <div className="item">
         <i className={this.props.icon + ' icon'}></i>
         <div className="content">
-          <div style={{ maxWidth: '50ch', textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }}>
+          <div style={{ maxWidth: '50ch' }}>
             {this.props.children}
           </div>
         </div>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5882053/169542711-c410b95e-753e-44fc-8ee9-0c12187a4e54.png)

After:

![image](https://user-images.githubusercontent.com/5882053/169542653-69123779-cc78-415c-87e6-62b167842b76.png)

Still does not parse text for links (unless it starts with a link) but at least we're no longer hiding user input.

Closes #206